### PR TITLE
Make character layers assignable

### DIFF
--- a/teanga/corpus.py
+++ b/teanga/corpus.py
@@ -163,7 +163,7 @@ class Corpus:
             if len(args) == 1:
                 doc_id = teanga_id_for_doc(self.doc_ids,
                         **{char_layers[0]: args[0]})
-                doc = Document(self.meta, id=doc_id, **{char_layers[0]: args[0]})
+                doc = Document(self.meta, id=doc_id, corpus_ref=self, **{char_layers[0]: args[0]})
                 if self.corpus:
                     self.corpus.add_doc({ char_layers[0]: args[0] })
                     doc.corpus = self.corpus
@@ -173,7 +173,7 @@ class Corpus:
             elif len(kwargs) == 1 and list(kwargs.keys())[0] == char_layers[0]:
                 doc_id = teanga_id_for_doc(self.doc_ids,
                                            **kwargs)
-                doc = Document(self.meta, id=doc_id, **kwargs)
+                doc = Document(self.meta, id=doc_id, corpus_ref=self, **kwargs)
                 if self.corpus:
                     self.corpus.add_doc(**kwargs)
                     doc.corpus = self.corpus
@@ -191,7 +191,7 @@ class Corpus:
             if set(kwargs.keys()).issubset(set(char_layers)):
                 doc_id = teanga_id_for_doc(self.doc_ids,
                                            **kwargs)
-                doc = Document(self.meta, id=doc_id, **kwargs)
+                doc = Document(self.meta, id=doc_id, corpus_ref=self, **kwargs)
                 if self.corpus:
                     self.corpus.add_doc(kwargs)
                     doc.corpus = self.corpus
@@ -201,6 +201,30 @@ class Corpus:
             else:
                 raise Exception("Invalid arguments, please specify the text " +
                                 "or use correct layer names.")
+    def update_doc(self, old_id : str, doc: Document) -> str:
+        """Replace a particular document indicated by an identifier
+        with a new document object.
+
+        Args:
+            old_id: str
+                The identifier of the document to replace.
+            doc: Document
+                The new document object.
+
+        Returns:
+            The identifier of the new document.
+        """
+        if self.corpus:
+            self.corpus.update_doc(old_id,
+                                   {name: layer.raw
+                                    for (name, layer) in doc.layers.items()})
+        else:
+            if old_id in self._docs:
+                del self._docs[old_id]
+            doc_id = teanga_id_for_doc(self.doc_ids,
+                                       **doc.character_layers())
+            self._docs[doc_id] = doc
+            return doc_id
 
     @property
     def doc_ids(self) -> Iterable[str]:
@@ -231,7 +255,8 @@ class Corpus:
         if self.corpus:
             for doc_id in self.corpus.order:
                 yield Document(self.meta, id=doc_id, corpus=self.corpus,
-                                        **self.corpus.get_doc_by_id(doc_id))
+                               corpus_ref=self,
+                               **self.corpus.get_doc_by_id(doc_id))
         else:
             for doc in self._docs.items():
                 yield doc[1]
@@ -257,6 +282,7 @@ class Corpus:
         """
         if self.corpus:
             return Document(self.meta, id=doc_id, corpus=self.corpus,
+                            corpus_ref=self,
                             **self.corpus.get_doc_by_id(doc_id))
         else:
             if doc_id in self._docs:
@@ -881,11 +907,11 @@ def _corpus_hook(dct : dict) -> Corpus:
               if not key.startswith("_")}
     if "_order" in dct:
         for doc_id in dct["_order"]:
-            c._docs[doc_id] = Document(c.meta, id=doc_id, **dct[doc_id])
+            c._docs[doc_id] = Document(c.meta, id=doc_id, corpus_ref=c, **dct[doc_id])
     else:
         for doc_id, value in dct.items():
             if not doc_id.startswith("_"):
-                doc = Document(c.meta, id=doc_id, **value)
+                doc = Document(c.meta, id=doc_id, corpus_ref=c, **value)
                 text_fields = {
                         field: value for field, value in value.items()
                         if isinstance(value, str) and not field.startswith("_")

--- a/teanga/document.py
+++ b/teanga/document.py
@@ -13,11 +13,12 @@ class Document:
 
     """
     def __init__(self, meta:dict[str,Union[LayerDesc,dict]],
-                 corpus=None, id=None, **kwargs):
+                 corpus=None, id=None, corpus_ref=None, **kwargs):
         self._meta = meta
         self.layers = {}
         self.corpus = None
         self.id = None
+        self._corpus_ref = corpus_ref
         self.add_layers({key: value
                          for key, value in kwargs.items()
                          if not key.startswith("_")})
@@ -79,9 +80,14 @@ class Document:
         if self._meta[name].layer_type not in ["characters", "seq", "span", "div", "element"]:
             raise Exception("Invalid layer type " + self._meta[name].layer_type)
         if self._meta[name].layer_type == "characters":
-            if self.id:
+            if self.id and not self._corpus_ref:
                 raise Exception("Cannot add character layer to existing document.")
-            self.layers[name] = CharacterLayer(name, self, str(value))
+            elif self.id and self._corpus_ref:
+                old_id = self.id
+                self.layers[name] = CharacterLayer(name, self, str(value))
+                self.id = self._corpus_ref.update_doc(old_id, self)
+            else:
+                self.layers[name] = CharacterLayer(name, self, str(value))
         elif self._meta[name].base is None:
             raise Exception("Non-character layer " + name + " must have a base.")
         elif (self._meta[name].base not in self._meta):
@@ -140,7 +146,7 @@ class Document:
 
     def __setattr__(self, name:str, value) -> None:
         """Set the value of a layer."""
-        if name != "layers" and name != "_meta" and name != "corpus" and name != "id" and name != "_metadata":
+        if name != "layers" and name != "_meta" and name != "corpus" and name != "id" and name != "_metadata" and name != "_corpus_ref":
             self.__setitem__(name, value)
         else:
             super().__setattr__(name, value)
@@ -204,6 +210,12 @@ class Document:
     @deprecated(reason="Access layers using __getitem__ instead, e.g., doc['text']")
     def get_layer(self, name:str):
         return self[name]
+
+    def character_layers(self) -> dict[str, str]:
+        """Get the character layers for this document (used to calculate the ID)"""
+        return {layer: self.layers[layer].raw
+                for layer in self.layers
+                if self._meta[layer].layer_type == "characters"}
 
     @property
     def meta(self):

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -21,4 +21,15 @@ def test_indexes1():
         print(doc.ner.indexes("text"))
         assert doc.ner.text == ["John Doe", "New York"]
 
+def test_add_metadata():
+    corpus = teanga.text_corpus()
+    doc = corpus.add_doc("test")
+    doc._author = "me"
+    print(doc._author)
 
+def test_update_character_layer():
+    corpus = teanga.text_corpus()
+    doc = corpus.add_doc(text="This is a document.")
+    assert doc.id == "Kjco"
+    doc.text = "New text"
+    assert doc.id == "/C+4"


### PR DESCRIPTION
This change allows character layers to be updatable. In this case, the identifier of the document will be recalculated

Fixes #57